### PR TITLE
feat: Respect SSH config Host and HostName directives for hostname re…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/kevinburke/ssh_config v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kevinburke/ssh_config v1.4.0 h1:6xxtP5bZ2E4NF5tuQulISpTO2z8XbtH8cg1PWkxoFkQ=
+github.com/kevinburke/ssh_config v1.4.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=


### PR DESCRIPTION
…solution

Implements GitHub issue #11 to resolve hostnames via SSH config files before attempting DNS resolution, matching OpenSSH behavior.

Changes:
- Add github.com/kevinburke/ssh_config dependency for parsing SSH config
- Implement resolveHostFromSSHConfig() to check ~/.ssh/config and /etc/ssh/ssh_config
- Implement getHostnameFromConfig() to parse individual config files
- Update Connect() and connectViaJumpHost() to resolve hostnames via SSH config
- Add comprehensive unit tests for SSH config resolution (18 test cases)
- Test coverage remains at 80.0%

The implementation follows SSH config precedence:
1. User config: ~/.ssh/config
2. System config: /etc/ssh/ssh_config
3. Falls back to original hostname if not found in config

This enables users to use SSH config aliases and hostname mappings without needing to add entries to /etc/hosts or use IP addresses directly.

Example SSH config:
```
Host web-server
    HostName 192.168.1.100
    User admin
```

Now works with:
```bash
platform-spec test remote web-server spec.yaml
```

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)